### PR TITLE
Fix null prop values within assignInlineVars

### DIFF
--- a/.changeset/purple-dancers-confess.md
+++ b/.changeset/purple-dancers-confess.md
@@ -1,0 +1,5 @@
+---
+'rainbow-sprinkles': patch
+---
+
+Fixed processing of null or undefined prop values

--- a/packages/rainbow-sprinkles/src/__tests__/assignInlineVars.test.ts
+++ b/packages/rainbow-sprinkles/src/__tests__/assignInlineVars.test.ts
@@ -36,6 +36,15 @@ test('dynamic', () => {
   });
 });
 
+test('ignores null and undefined prop values', () => {
+  const config = makeConfig({
+    dynamic: { mobile: 'a', tablet: 'b', desktop: 'c' },
+  });
+
+  expect(run(config, null)).toMatchObject({});
+  expect(run(config, undefined)).toMatchObject({});
+});
+
 test('static', () => {
   const config = makeConfig({
     block: {

--- a/packages/rainbow-sprinkles/src/assignInlineVars.ts
+++ b/packages/rainbow-sprinkles/src/assignInlineVars.ts
@@ -25,7 +25,7 @@ function _assignInlineVars<Conditions extends BaseConditions>(
   const bps = propValue as { [k in keyof Conditions]?: string };
 
   // If no entries, exit gracefully
-  if (bps && Object.keys(bps).length < 1) {
+  if ((bps && Object.keys(bps).length < 1) || bps == null) {
     return {};
   }
 


### PR DESCRIPTION
## Description

This fixes and adds a test for passing null or undefined to a configured system prop within `assignInlineVars`.

Fixes #23 

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/oss-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
