### PR TITLE
Cleanup contribution links, error log prefixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -30,7 +30,5 @@ Please provide the version number where this issue was encountered.
 
 ## Checklist
 
-<!-- TODO: Update the link below to point to your project's contributing guidelines -->
-
-- [ ] I have read the [contributing guidelines](https://github.com/wayfair-incubator/oss-template/blob/main/CONTRIBUTING.md)
+- [ ] I have read the [contributing guidelines](https://github.com/wayfair/rainbow-sprinkles/blob/main/CONTRIBUTING.md)
 - [ ] I have verified this does not duplicate an existing issue

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,9 +15,7 @@ Note that by _not_ including a description, you are asking reviewers to do extra
 
 ## Checklist
 
-<!-- TODO: Update the link below to point to your project's contributing guidelines -->
-
-- [ ] I have read the [contributing guidelines](https://github.com/wayfair-incubator/oss-template/blob/main/CONTRIBUTING.md)
+- [ ] I have read the [contributing guidelines](https://github.com/wayfair/rainbow-sprinkles/blob/main/CONTRIBUTING.md)
 - [ ] Existing issues have been referenced (where applicable)
 - [ ] I have verified this change is not present in other open pull requests
 - [ ] Functionality is documented

--- a/packages/rainbow-sprinkles/src/assignClasses.ts
+++ b/packages/rainbow-sprinkles/src/assignClasses.ts
@@ -29,7 +29,7 @@ export function assignClasses<Conditions extends BaseConditions>(
     // Quietly warn
     // eslint-disable-next-line no-console
     console.error(
-      `[Rainbow Sprinkles]: invalid value provided to prop '${propName}'. Expected one of ${Object.keys(
+      `Homebase: invalid value provided to prop '${propName}'. Expected one of ${Object.keys(
         classes,
       )
         .map((className) => `"${className}"`)
@@ -61,7 +61,7 @@ export function assignClasses<Conditions extends BaseConditions>(
       // Quietly warn
       // eslint-disable-next-line no-console
       console.error(
-        `[Rainbow Sprinkles]: invalid value provided to prop '${propName}'. Expected one of ${Object.keys(
+        `Homebase: invalid value provided to prop '${propName}'. Expected one of ${Object.keys(
           classes,
         )
           .map((className) => `"${className}"`)

--- a/packages/rainbow-sprinkles/src/assignClasses.ts
+++ b/packages/rainbow-sprinkles/src/assignClasses.ts
@@ -29,7 +29,7 @@ export function assignClasses<Conditions extends BaseConditions>(
     // Quietly warn
     // eslint-disable-next-line no-console
     console.error(
-      `Homebase: invalid value provided to prop '${propName}'. Expected one of ${Object.keys(
+      `[Rainbow Sprinkles]: invalid value provided to prop '${propName}'. Expected one of ${Object.keys(
         classes,
       )
         .map((className) => `"${className}"`)
@@ -61,7 +61,7 @@ export function assignClasses<Conditions extends BaseConditions>(
       // Quietly warn
       // eslint-disable-next-line no-console
       console.error(
-        `Homebase: invalid value provided to prop '${propName}'. Expected one of ${Object.keys(
+        `[Rainbow Sprinkles]: invalid value provided to prop '${propName}'. Expected one of ${Object.keys(
           classes,
         )
           .map((className) => `"${className}"`)


### PR DESCRIPTION
## Description

Fixes some lingering todos in templates for issues/prs + replaces `Homebase` log prefixes with `[Rainbow Sprinkles]` (let me know if you want me to remove this change / change it to something else)

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/oss-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
