### PR TITLE
Fix erroring with numbers

### DIFF
--- a/.changeset/honest-flowers-clap.md
+++ b/.changeset/honest-flowers-clap.md
@@ -1,0 +1,5 @@
+---
+'rainbow-sprinkles': patch
+---
+
+Fixes errors when using Numbers as values

--- a/packages/rainbow-sprinkles/src/__tests__/trim-dollar.test.ts
+++ b/packages/rainbow-sprinkles/src/__tests__/trim-dollar.test.ts
@@ -16,3 +16,8 @@ it('matches negative values with -', () => {
   expect(trim$('-$2500')).toBe('-2500');
   expect(trim$('-$gray100')).toBe('-gray100');
 });
+
+it('supports numbers', () => {
+  expect(trim$(0)).toBe('0');
+  expect(trim$(250)).toBe('250');
+});

--- a/packages/rainbow-sprinkles/src/utils.ts
+++ b/packages/rainbow-sprinkles/src/utils.ts
@@ -1,12 +1,14 @@
 const VALUE_REGEX = /(-)?\$(\w*)/;
 
 export function trim$(rawValue: string | number): string {
-  const v = `${rawValue}`;
-  const matches = v.match(VALUE_REGEX);
+  if (typeof rawValue === 'number') {
+    return `${rawValue}`;
+  }
+  const matches = rawValue.match(VALUE_REGEX);
   if (matches) {
     return (matches[1] ?? '').concat(matches[2]);
   }
-  return v;
+  return rawValue;
 }
 
 export function mapValues<

--- a/packages/rainbow-sprinkles/src/utils.ts
+++ b/packages/rainbow-sprinkles/src/utils.ts
@@ -1,11 +1,12 @@
 const VALUE_REGEX = /(-)?\$(\w*)/;
 
-export function trim$(rawValue: string): string {
-  const matches = rawValue.match(VALUE_REGEX);
+export function trim$(rawValue: string | number): string {
+  const v = `${rawValue}`;
+  const matches = v.match(VALUE_REGEX);
   if (matches) {
     return (matches[1] ?? '').concat(matches[2]);
   }
-  return rawValue;
+  return v;
 }
 
 export function mapValues<


### PR DESCRIPTION
## Description

We weren't properly handling number values. Intentionally not coercing to a pixel value like some other similar libraries do, since that can be confusing. Instead it just stringifies the value.

This will support things like `margin={0}`, which will emit `margin: 0`

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair/rainbow-sprinkles/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
