### PR TITLE
Fixed stringification of number values

### DIFF
--- a/.changeset/popular-pumpkins-retire.md
+++ b/.changeset/popular-pumpkins-retire.md
@@ -1,0 +1,5 @@
+---
+'rainbow-sprinkles': patch
+---
+
+Fixed stringification of number values

--- a/packages/rainbow-sprinkles/src/__tests__/assignClasses.test.ts
+++ b/packages/rainbow-sprinkles/src/__tests__/assignClasses.test.ts
@@ -92,3 +92,26 @@ test('static and dynamic', () => {
     }),
   ).toBe('1 b z');
 });
+
+test('supports number values', () => {
+  const config: CreateStylesOutput = {
+    dynamic: {
+      default: 'a',
+      conditions: { mobile: 'a', tablet: 'b', desktop: 'c' },
+    },
+    name: 'lineHeight',
+    vars: {
+      conditions: { mobile: 'a', tablet: 'b', desktop: 'c' },
+      default: 'a',
+    },
+  };
+
+  expect(
+    assignClasses(config, {
+      mobile: 1,
+      tablet: 3,
+    }),
+  ).toBe('a b');
+
+  expect(assignClasses(config, 'foo')).toBe('a');
+});

--- a/packages/rainbow-sprinkles/src/__tests__/assignInlineVars.test.ts
+++ b/packages/rainbow-sprinkles/src/__tests__/assignInlineVars.test.ts
@@ -119,3 +119,30 @@ test('static and dynamic', () => {
 
   expect(assignInlineVars(config, 'block')).toEqual({});
 });
+
+test('supports number values', () => {
+  const config: CreateStylesOutput = {
+    dynamic: {
+      default: 'a',
+      conditions: { mobile: 'a', tablet: 'b', desktop: 'c' },
+    },
+    vars: {
+      default: '--mobile',
+      conditions: {
+        mobile: '--mobile',
+        tablet: '--tablet',
+        desktop: '--desktop',
+      },
+    },
+    dynamicScale: true,
+    name: 'lineHeight',
+  };
+
+  expect(assignInlineVars(config, 2)).toEqual({
+    '--mobile': '2',
+  });
+  expect(assignInlineVars(config, { mobile: 1, tablet: 3 })).toEqual({
+    '--mobile': '1',
+    '--tablet': '3',
+  });
+});

--- a/packages/rainbow-sprinkles/src/__tests__/trim-dollar.test.ts
+++ b/packages/rainbow-sprinkles/src/__tests__/trim-dollar.test.ts
@@ -16,3 +16,8 @@ it('matches negative values with -', () => {
   expect(trim$('-$2500')).toBe('-2500');
   expect(trim$('-$gray100')).toBe('-gray100');
 });
+
+it('supports numbers', () => {
+  expect(trim$(0)).toBe(0);
+  expect(trim$(250)).toBe(250);
+});

--- a/packages/rainbow-sprinkles/src/__tests__/trim-dollar.test.ts
+++ b/packages/rainbow-sprinkles/src/__tests__/trim-dollar.test.ts
@@ -16,8 +16,3 @@ it('matches negative values with -', () => {
   expect(trim$('-$2500')).toBe('-2500');
   expect(trim$('-$gray100')).toBe('-gray100');
 });
-
-it('supports numbers', () => {
-  expect(trim$(0)).toBe('0');
-  expect(trim$(250)).toBe('250');
-});

--- a/packages/rainbow-sprinkles/src/assignClasses.ts
+++ b/packages/rainbow-sprinkles/src/assignClasses.ts
@@ -12,7 +12,7 @@ export function assignClasses(
   const { dynamic, values, name: propName } = propertyConfig;
 
   // Value is a string or number, ie not responsive
-  if (typeof propValue === 'string') {
+  if (typeof propValue === 'string' || typeof propValue === 'number') {
     const value = trim$(propValue);
     // Check for static value first
     if (values?.[value]) {

--- a/packages/rainbow-sprinkles/src/assignInlineVars.ts
+++ b/packages/rainbow-sprinkles/src/assignInlineVars.ts
@@ -9,7 +9,7 @@ function _assignInlineVars(
   const { vars, dynamicScale, values, dynamic } = propertyConfig;
 
   // Value is a string, ie not responsive
-  if (typeof propValue === 'string') {
+  if (typeof propValue === 'string' || typeof propValue === 'number') {
     const parsedValue = trim$(propValue);
     // If the propValue matches a static value,
     // don't assign any variables
@@ -21,7 +21,7 @@ function _assignInlineVars(
       return {};
     }
     return assignInlineVars({
-      [vars.default]: dynamicScale?.[parsedValue] ?? propValue,
+      [vars.default]: dynamicScale?.[parsedValue] ?? `${propValue}`,
     });
   }
 
@@ -41,7 +41,7 @@ function _assignInlineVars(
           return acc;
         }
         hasProperty = true;
-        acc[vars.conditions[bp]] = dynamicScale?.[parsedValue] ?? value;
+        acc[vars.conditions[bp]] = dynamicScale?.[parsedValue] ?? `${value}`;
       }
       return acc;
     },

--- a/packages/rainbow-sprinkles/src/utils.ts
+++ b/packages/rainbow-sprinkles/src/utils.ts
@@ -1,12 +1,11 @@
 const VALUE_REGEX = /(-)?\$(\w*)/;
 
-export function trim$(rawValue: string | number): string {
-  if (typeof rawValue === 'number') {
-    return `${rawValue}`;
-  }
-  const matches = rawValue.match(VALUE_REGEX);
-  if (matches) {
-    return (matches[1] ?? '').concat(matches[2]);
+export function trim$(rawValue: string | number): string | number {
+  if (typeof rawValue === 'string') {
+    const matches = rawValue.match(VALUE_REGEX);
+    if (matches) {
+      return (matches[1] ?? '').concat(matches[2]);
+    }
   }
   return rawValue;
 }


### PR DESCRIPTION
## Description

#80 was an ineffective fix. It fixed the error caused by passing numbers, but didn't actually support stringifying values when the classes and inline styles are created.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair/rainbow-sprinkles/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
