### PR TITLE
Fixed class creation being skipped when property values are zero

### DIFF
--- a/.changeset/little-olives-hang.md
+++ b/.changeset/little-olives-hang.md
@@ -1,0 +1,5 @@
+---
+'rainbow-sprinkles': patch
+---
+
+Fixed classes not being created when property value is 0

--- a/packages/rainbow-sprinkles/src/__tests__/assignClasses.test.ts
+++ b/packages/rainbow-sprinkles/src/__tests__/assignClasses.test.ts
@@ -115,3 +115,26 @@ test('supports number values', () => {
 
   expect(assignClasses(config, 'foo')).toBe('a');
 });
+
+test('supports 0 values', () => {
+  const config: CreateStylesOutput = {
+    dynamic: {
+      default: 'a',
+      conditions: { mobile: 'a', tablet: 'b', desktop: 'c' },
+    },
+    name: 'flexShrink',
+    vars: {
+      conditions: { mobile: 'a', tablet: 'b', desktop: 'c' },
+      default: 'a',
+    },
+  };
+
+  expect(
+    assignClasses(config, {
+      mobile: 0,
+      tablet: 1,
+    }),
+  ).toBe('a b');
+
+  expect(assignClasses(config, 0)).toBe('a');
+});

--- a/packages/rainbow-sprinkles/src/assignClasses.ts
+++ b/packages/rainbow-sprinkles/src/assignClasses.ts
@@ -5,7 +5,7 @@ export function assignClasses(
   propertyConfig: CreateStylesOutput,
   propValue: unknown,
 ): string {
-  if (!propValue) {
+  if (!propValue && propValue !== 0) {
     return '';
   }
 


### PR DESCRIPTION
## Description

Addressing https://github.com/wayfair/rainbow-sprinkles/issues/89

For numeric property types, such as FlexShrink, zero-values are sometimes useful, but were being evaluated as falsey in the assignClasses function, resulting in no classnames being created.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/wayfair/rainbow-sprinkles/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [x ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
