### PR TITLE
Inline property styles if no conditions

### DIFF
--- a/.changeset/mighty-nails-dream.md
+++ b/.changeset/mighty-nails-dream.md
@@ -1,0 +1,5 @@
+---
+'rainbow-sprinkles': minor
+---
+
+When no conditions are used with a dynamic sprinkle property, the style will be completely inlined instead of using CSS variables

--- a/babel-jest.config.js
+++ b/babel-jest.config.js
@@ -1,5 +1,4 @@
 module.exports = {
   extends: './babel.config',
   presets: [['@babel/preset-env', { targets: { node: 'current' } }]],
-  plugins: [require.resolve('@vanilla-extract/babel-plugin')],
 };

--- a/example/.babelrc
+++ b/example/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": ["next/babel"],
-  "plugins": ["@vanilla-extract/babel-plugin"]
-}

--- a/example/package.json
+++ b/example/package.json
@@ -9,10 +9,9 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@vanilla-extract/babel-plugin": "1.2.0",
-    "@vanilla-extract/css": "1.9.1",
-    "@vanilla-extract/dynamic": "2.0.2",
-    "@vanilla-extract/next-plugin": "2.0.2",
+    "@vanilla-extract/css": "1.9.2",
+    "@vanilla-extract/dynamic": "2.0.3",
+    "@vanilla-extract/next-plugin": "2.1.1",
     "next": "12.3.0",
     "rainbow-sprinkles": "workspace:*",
     "react": "18.2.0",

--- a/packages/rainbow-sprinkles/package.json
+++ b/packages/rainbow-sprinkles/package.json
@@ -43,8 +43,8 @@
   },
   "devDependencies": {
     "@types/jest": "29.0.0",
-    "@vanilla-extract/css": "1.9.1",
-    "@vanilla-extract/dynamic": "2.0.2",
+    "@vanilla-extract/css": "1.9.2",
+    "@vanilla-extract/dynamic": "2.0.3",
     "jest": "28.1.3"
   },
   "peerDependencies": {

--- a/packages/rainbow-sprinkles/src/__tests__/assignClasses.test.ts
+++ b/packages/rainbow-sprinkles/src/__tests__/assignClasses.test.ts
@@ -34,7 +34,7 @@ test('dynamic', () => {
     }),
   ).toBe('a b');
 
-  expect(fn(config, 'foo')).toBe('a');
+  expect(fn(config, 'foo')).toBe('');
 });
 
 test('static', () => {
@@ -137,7 +137,7 @@ test('supports number values', () => {
     }),
   ).toBe('a b');
 
-  expect(fn(config, 'foo')).toBe('a');
+  expect(fn(config, 'foo')).toBe('');
 });
 
 test('supports 0 values', () => {
@@ -160,7 +160,7 @@ test('supports 0 values', () => {
     }),
   ).toBe('a b');
 
-  expect(fn(config, 0)).toBe('a');
+  expect(fn(config, 0)).toBe('');
 });
 
 test('caching', () => {

--- a/packages/rainbow-sprinkles/src/__tests__/assignVars.test.ts
+++ b/packages/rainbow-sprinkles/src/__tests__/assignVars.test.ts
@@ -30,7 +30,7 @@ test('dynamic', () => {
   };
 
   expect(fn(config, 'foo')).toEqual({
-    '--mobile': 'foo',
+    display: 'foo',
   });
   expect(fn(config, { mobile: 'foo', tablet: 'bar' })).toEqual({
     '--mobile': 'foo',
@@ -149,7 +149,7 @@ test('supports number values', () => {
   };
 
   expect(fn(config, 2)).toEqual({
-    '--mobile': '2',
+    lineHeight: '2',
   });
   expect(fn(config, { mobile: 1, tablet: 3 })).toEqual({
     '--mobile': '1',

--- a/packages/rainbow-sprinkles/src/__tests__/createRainbowSprinkles.test.ts
+++ b/packages/rainbow-sprinkles/src/__tests__/createRainbowSprinkles.test.ts
@@ -82,10 +82,10 @@ describe('dynamic properties only', () => {
       expect(
         rainbowSprinkles({ color: '$gray50', padding: '40px' }),
       ).toMatchObject({
-        className: 'color-mobile padding-mobile',
+        className: '',
         style: {
-          '--color-mobile': vars.color['gray50'],
-          '--padding-mobile': '40px',
+          color: vars.color['gray50'],
+          padding: '40px',
         },
       });
     });
@@ -98,21 +98,21 @@ describe('dynamic properties only', () => {
           padding: '-$1x -$3x',
         }),
       ).toMatchObject({
-        className: 'color-mobile paddingTop-mobile padding-mobile',
+        className: '',
         style: {
-          '--color-mobile': '-$gray50',
-          '--paddingTop-mobile': vars.space['-2x'],
-          '--padding-mobile': `${vars.space['-1x']} ${vars.space['-3x']}`,
+          color: '-$gray50',
+          paddingTop: vars.space['-2x'],
+          padding: `${vars.space['-1x']} ${vars.space['-3x']}`,
         },
       });
     });
 
     it('handles shorthands', () => {
       expect(rainbowSprinkles({ px: '$1x' })).toMatchObject({
-        className: 'paddingLeft-mobile paddingRight-mobile',
+        className: '',
         style: {
-          '--paddingLeft-mobile': vars.space['1x'],
-          '--paddingRight-mobile': vars.space['1x'],
+          paddingLeft: vars.space['1x'],
+          paddingRight: vars.space['1x'],
         },
       });
     });
@@ -301,9 +301,9 @@ describe('static and dynamic properties', () => {
 
       it('creates class and var for dynamic value', () => {
         expect(rainbowSprinkles({ display: 'flex' })).toMatchObject({
-          className: 'display-mobile',
+          className: '',
           style: {
-            '--display-mobile': 'flex',
+            display: 'flex',
           },
         });
       });
@@ -326,7 +326,7 @@ describe('static and dynamic properties', () => {
         });
       });
 
-      it.only('handles just static values in a conditional object', () => {
+      it('handles just static values in a conditional object', () => {
         expect(
           rainbowSprinkles({
             display: { mobile: 'block', tablet: 'inline-block' },
@@ -357,7 +357,7 @@ describe('static and dynamic properties', () => {
           style: {},
         });
       });
-      it.skip('returns nothing for non-configured value', () => {
+      it('returns nothing for non-configured value', () => {
         // @ts-expect-error
         expect(rainbowSprinkles({ textAlign: 'center' })).toMatchObject({
           className: '',
@@ -372,7 +372,7 @@ describe('static and dynamic properties', () => {
         ).toMatchObject({
           className: 'textAlign-left-mobile',
         });
-        expect(console.error).toHaveBeenCalledTimes(2);
+        expect(consoleError).toHaveBeenCalledTimes(2);
       });
     });
 

--- a/packages/rainbow-sprinkles/src/__tests__/createRainbowSprinkles.test.ts
+++ b/packages/rainbow-sprinkles/src/__tests__/createRainbowSprinkles.test.ts
@@ -326,7 +326,7 @@ describe('static and dynamic properties', () => {
         });
       });
 
-      it('handles just static values in a conditional object', () => {
+      it.only('handles just static values in a conditional object', () => {
         expect(
           rainbowSprinkles({
             display: { mobile: 'block', tablet: 'inline-block' },
@@ -357,7 +357,7 @@ describe('static and dynamic properties', () => {
           style: {},
         });
       });
-      it('returns nothing for non-configured value', () => {
+      it.skip('returns nothing for non-configured value', () => {
         // @ts-expect-error
         expect(rainbowSprinkles({ textAlign: 'center' })).toMatchObject({
           className: '',
@@ -422,11 +422,10 @@ describe('static and dynamic properties and shorthands', () => {
           mx: '24px',
         }),
       ).toMatchObject({
-        className:
-          'marginLeft-mobile marginRight-mobile backgroundColor-gray50-mobile',
+        className: 'backgroundColor-gray50-mobile',
         style: {
-          '--marginLeft-mobile': '24px',
-          '--marginRight-mobile': '24px',
+          marginLeft: '24px',
+          marginRight: '24px',
         },
       });
     });
@@ -480,11 +479,11 @@ describe('dynamic (no conditions)', () => {
     expect(
       rainbowSprinkles({ color: '$gray50', padding: '40px', bg: '$gray50' }),
     ).toMatchObject({
-      className: 'background color padding',
+      className: '',
       style: {
-        '--color': vars.color.gray50,
-        '--background': vars.color.gray50,
-        '--padding': '40px',
+        background: vars.color.gray50,
+        color: vars.color.gray50,
+        padding: '40px',
       },
     });
   });

--- a/packages/rainbow-sprinkles/src/assignClasses.ts
+++ b/packages/rainbow-sprinkles/src/assignClasses.ts
@@ -37,6 +37,7 @@ export function assignClasses(
     }
 
     if (dynamic) {
+      // When there's no conditions and dynamic, we just use inline styles
       const result = '';
       cache.set(cacheKey, result);
       return result;
@@ -74,7 +75,10 @@ export function assignClasses(
 
       // Check for static value first
       if (values) {
-        if (Array.isArray(staticScale) && staticScale.includes(propValue)) {
+        if (
+          Array.isArray(staticScale) &&
+          staticScale.includes(rawValueAtCondition)
+        ) {
           const result = values[rawValueAtCondition].conditions[condition];
           cache.set(cacheKey, result);
           return result;

--- a/packages/rainbow-sprinkles/src/assignClasses.ts
+++ b/packages/rainbow-sprinkles/src/assignClasses.ts
@@ -66,9 +66,7 @@ export function assignClasses(
     .map((condition) => {
       const rawValueAtCondition = `${propValue[condition]}`;
 
-      const cacheKey = condition
-        ? `${condition}${rawValueAtCondition}`
-        : rawValueAtCondition;
+      const cacheKey = `${condition}${rawValueAtCondition}`;
 
       if (cache.has(cacheKey)) {
         return cache.get(cacheKey);
@@ -82,7 +80,7 @@ export function assignClasses(
           return result;
         }
 
-        const parsedValue = getValueConfig(`${rawValueAtCondition}`, values);
+        const parsedValue = getValueConfig(rawValueAtCondition, values);
         if (parsedValue) {
           const result = parsedValue.conditions[condition];
           cache.set(cacheKey, result);

--- a/packages/rainbow-sprinkles/src/assignVars.ts
+++ b/packages/rainbow-sprinkles/src/assignVars.ts
@@ -28,10 +28,7 @@ export function assignVars(
       return {};
     }
 
-    const result = {
-      [name]: parsedValue,
-    };
-    return result;
+    return { [name]: parsedValue };
   }
 
   // If no entries, exit gracefully

--- a/packages/rainbow-sprinkles/src/assignVars.ts
+++ b/packages/rainbow-sprinkles/src/assignVars.ts
@@ -6,7 +6,7 @@ export function assignVars(
   propValue: unknown,
   cache: Map<number | string, string>,
 ): CSSProperties {
-  const { vars, dynamicScale, values, dynamic } = propertyConfig;
+  const { name, vars, dynamicScale, values, dynamic } = propertyConfig;
 
   if (!dynamic) {
     return {};
@@ -29,7 +29,7 @@ export function assignVars(
     }
 
     const result = {
-      [vars.default]: parsedValue,
+      [name]: parsedValue,
     };
     return result;
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,10 +51,9 @@ importers:
       '@types/node': 18.7.14
       '@types/react': 18.0.18
       '@types/react-dom': 18.0.6
-      '@vanilla-extract/babel-plugin': 1.2.0
-      '@vanilla-extract/css': 1.9.1
-      '@vanilla-extract/dynamic': 2.0.2
-      '@vanilla-extract/next-plugin': 2.0.2
+      '@vanilla-extract/css': 1.9.2
+      '@vanilla-extract/dynamic': 2.0.3
+      '@vanilla-extract/next-plugin': 2.1.1
       eslint: 8.23.0
       eslint-config-next: 12.3.0
       next: 12.3.0
@@ -66,10 +65,9 @@ importers:
       typescript: 4.8.4
       webpack: 5.74.0
     dependencies:
-      '@vanilla-extract/babel-plugin': 1.2.0
-      '@vanilla-extract/css': 1.9.1
-      '@vanilla-extract/dynamic': 2.0.2
-      '@vanilla-extract/next-plugin': 2.0.2_next@12.3.0+webpack@5.74.0
+      '@vanilla-extract/css': 1.9.2
+      '@vanilla-extract/dynamic': 2.0.3
+      '@vanilla-extract/next-plugin': 2.1.1_next@12.3.0+webpack@5.74.0
       next: 12.3.0_biqbaboplfbrettd7655fr4n2y
       rainbow-sprinkles: link:../packages/rainbow-sprinkles
       react: 18.2.0
@@ -88,13 +86,13 @@ importers:
   packages/rainbow-sprinkles:
     specifiers:
       '@types/jest': 29.0.0
-      '@vanilla-extract/css': 1.9.1
-      '@vanilla-extract/dynamic': 2.0.2
+      '@vanilla-extract/css': 1.9.2
+      '@vanilla-extract/dynamic': 2.0.3
       jest: 28.1.3
     devDependencies:
       '@types/jest': 29.0.0
-      '@vanilla-extract/css': 1.9.1
-      '@vanilla-extract/dynamic': 2.0.2
+      '@vanilla-extract/css': 1.9.2
+      '@vanilla-extract/dynamic': 2.0.3
       jest: 28.1.3
 
 packages:
@@ -1466,8 +1464,8 @@ packages:
       '@jridgewell/trace-mapping': 0.3.9
     dev: false
 
-  /@emotion/hash/0.8.0:
-    resolution: {integrity: sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==}
+  /@emotion/hash/0.9.0:
+    resolution: {integrity: sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ==}
 
   /@eslint/eslintrc/1.3.1:
     resolution: {integrity: sha512-OhSY22oQQdw3zgPOOwdoj01l/Dzl1Z+xyUP33tkSN+aqyEhymJCcPHyXt+ylW8FSe0TfRC2VG+ROQOapD0aZSQ==}
@@ -2406,20 +2404,10 @@ packages:
       - supports-color
     dev: false
 
-  /@vanilla-extract/babel-plugin/1.2.0:
-    resolution: {integrity: sha512-4R+hqoyzoyJIrE+NgrYxZuL6GqGH28hiBrPUOxwtvqnJJ5WnUl2/WzItLDDH9YT1Auwl3cIR7pcbrV6HIchORA==}
+  /@vanilla-extract/css/1.9.2:
+    resolution: {integrity: sha512-CE5+R89LOl9XG5dRwEIvVyl/YcS2GkqjdE/XnGJ+p7Fp6Exu08fifv7tY87XxFeCIRAbc9psM+h4lF+wC3Y0fg==}
     dependencies:
-      '@babel/core': 7.18.13
-      '@babel/template': 7.18.10
-      '@vanilla-extract/integration': 5.0.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@vanilla-extract/css/1.9.1:
-    resolution: {integrity: sha512-pu2SFiff5jRhPwvGoj8cM5l/qIyLvigOmy22ss5DGjwV5pJYezRjDLxWumi2luIwioMWvh9EozCjyfH8nq+7fQ==}
-    dependencies:
-      '@emotion/hash': 0.8.0
+      '@emotion/hash': 0.9.0
       '@vanilla-extract/private': 1.0.3
       ahocorasick: 1.0.2
       chalk: 4.1.2
@@ -2431,22 +2419,10 @@ packages:
       media-query-parser: 2.0.2
       outdent: 0.8.0
 
-  /@vanilla-extract/dynamic/2.0.2:
-    resolution: {integrity: sha512-U4nKaEQ8Kuz+exXEr51DUpyaOuzo24/S/k1YbDPQR06cYcNjQqvwFRnwWtZ+9ImocqM1wTKtzrdUgSTtLGIwAg==}
+  /@vanilla-extract/dynamic/2.0.3:
+    resolution: {integrity: sha512-Rglfw2gXAYiBzAQ4jgUG7rBgE2c88e/zcG27ZVoIqMHVq56wf2C1katGMm1yFMNBgzqM7oBNYzz4YOMzznydkg==}
     dependencies:
       '@vanilla-extract/private': 1.0.3
-
-  /@vanilla-extract/integration/5.0.1:
-    resolution: {integrity: sha512-HRV/HvC/lihb9wT3x5s7pf5qLjqxSd9nBePJ10juOuMB5cl2ZClEcts076m9BuRKM3wRK2h7KuwkNsaUtjujxQ==}
-    dependencies:
-      '@vanilla-extract/css': 1.9.1
-      esbuild: 0.11.23
-      eval: 0.1.6
-      find-up: 5.0.0
-      javascript-stringify: 2.1.0
-      lodash: 4.17.21
-      outdent: 0.8.0
-    dev: false
 
   /@vanilla-extract/integration/6.0.0:
     resolution: {integrity: sha512-uBz4QAhKYswyhN3LYd4duuN3uq7WT1jKckd0sP2+Y8gL+6UXdhN9QOUvNBfvofkrYYWqS8efH4hnsGyyWW8f+w==}
@@ -2454,7 +2430,7 @@ packages:
       '@babel/core': 7.18.13
       '@babel/plugin-syntax-typescript': 7.18.6_@babel+core@7.18.13
       '@vanilla-extract/babel-plugin-debug-ids': 1.0.0
-      '@vanilla-extract/css': 1.9.1
+      '@vanilla-extract/css': 1.9.2
       esbuild: 0.11.23
       eval: 0.1.6
       find-up: 5.0.0
@@ -2474,12 +2450,12 @@ packages:
       - supports-color
     dev: false
 
-  /@vanilla-extract/next-plugin/2.0.2_next@12.3.0+webpack@5.74.0:
-    resolution: {integrity: sha512-91xtYoE/TVQcL9vkjN1sP8SDoDJVVuHOhwjeR3W1jgLFrKydrODRxmu9qzuRKcBVM2R7ayGdBQOKmm3HL2xpug==}
+  /@vanilla-extract/next-plugin/2.1.1_next@12.3.0+webpack@5.74.0:
+    resolution: {integrity: sha512-8+7WRL7JRv9w9MOwTpVi/ZDv3qXkxjkgJgxzS9wQJHjvdfcs0Xyq30ePeaJfBN4b6ClUeqOdj7UYa8fqKA8oOQ==}
     peerDependencies:
       next: '>=12.0.5'
     dependencies:
-      '@vanilla-extract/webpack-plugin': 2.1.12_webpack@5.74.0
+      '@vanilla-extract/webpack-plugin': 2.2.0_webpack@5.74.0
       browserslist: 4.21.3
       next: 12.3.0_biqbaboplfbrettd7655fr4n2y
     transitivePeerDependencies:
@@ -2490,12 +2466,12 @@ packages:
   /@vanilla-extract/private/1.0.3:
     resolution: {integrity: sha512-17kVyLq3ePTKOkveHxXuIJZtGYs+cSoev7BlP+Lf4916qfDhk/HBjvlYDe8egrea7LNPHKwSZJK/bzZC+Q6AwQ==}
 
-  /@vanilla-extract/webpack-plugin/2.1.12_webpack@5.74.0:
-    resolution: {integrity: sha512-8mAbIDEh9r7a5cgb3wcILzuhEbGNddV4/qvwogOlxhoGrP4deUKJHEtPURDviWZ+x/FzFZtZ3glWU7WD8+WN8A==}
+  /@vanilla-extract/webpack-plugin/2.2.0_webpack@5.74.0:
+    resolution: {integrity: sha512-EQrnT7gIki+Wm57eIRZRw6pi4M4VVnwiSp5OOcQF81XdZvoYXo51Ern7+dHKS+Xxli151BWTUsg/UZSpaAz29Q==}
     peerDependencies:
       webpack: ^4.30.0 || ^5.20.2
     dependencies:
-      '@vanilla-extract/integration': 5.0.1
+      '@vanilla-extract/integration': 6.0.0
       chalk: 4.1.2
       debug: 4.3.4
       loader-utils: 2.0.2


### PR DESCRIPTION
## Description

Experiment of directly inlining styles if no conditions are used.

For example:

```tsx
<Box mb="$2000" />
```

would translate to

```html
<div style="margin-bottom: var(--space-2000);"></div>
```

Instead of assigning a class and a CSS variable assignment on the inline style. If there are conditions, we use CSS to handle CSS specificity.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair/rainbow-sprinkles/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
