### PR TITLE
Fix: allow hyphen and dot in scale keys

### DIFF
--- a/.changeset/heavy-cherries-pretend.md
+++ b/.changeset/heavy-cherries-pretend.md
@@ -1,0 +1,5 @@
+---
+'rainbow-sprinkles': patch
+---
+
+Allow scale keys with hyphen or dot by modifying VALUE_REGEX

--- a/packages/rainbow-sprinkles/src/__tests__/createRainbowSprinkles.test.ts
+++ b/packages/rainbow-sprinkles/src/__tests__/createRainbowSprinkles.test.ts
@@ -179,7 +179,7 @@ describe('dynamic properties only', () => {
       `);
     });
 
-    describe('handles all scale keys', () => {
+    describe('parses scale values with hyphens, underscores, and periods', () => {
       test.each([
         ['$gray200', vars.color['gray200']],
         ['$gray-500', vars.color['gray-500']],
@@ -296,7 +296,7 @@ describe('static properties only', () => {
       `);
     });
 
-    describe('handles all scale keys', () => {
+    describe('parses scale values with hyphens, underscores, and periods', () => {
       test.each([
         ['$gray200', vars.color['gray200']],
         ['$gray-500', vars.color['gray-500']],

--- a/packages/rainbow-sprinkles/src/__tests__/createRainbowSprinkles.test.ts
+++ b/packages/rainbow-sprinkles/src/__tests__/createRainbowSprinkles.test.ts
@@ -15,6 +15,11 @@ const vars = {
     gray50: '#efefef',
     gray100: '#fefefe',
     gray200: '#333333',
+    'gray-500': '#6b7280',
+    'gray.500': '#6b7280',
+    gray_500: '#6b7280',
+    'gray--500': '#6b7280',
+    'colors.gray-500': '#6b7280',
   },
   borderRadius: {
     '0x': '0px',
@@ -173,6 +178,28 @@ describe('dynamic properties only', () => {
         }
       `);
     });
+
+    describe('handles all scale keys', () => {
+      test.each([
+        ['$gray200', vars.color['gray200']],
+        ['$gray-500', vars.color['gray-500']],
+        ['$gray.500', vars.color['gray.500']],
+        ['$gray_500', vars.color['gray_500']],
+        ['$gray--500', vars.color['gray--500']],
+        ['$colors.gray-500', vars.color['colors.gray-500']],
+      ])(`%s`, (key, value) => {
+        expect(
+          rainbowSprinkles({
+            color: key,
+          }),
+        ).toMatchObject({
+          className: 'color-mobile',
+          style: {
+            '--color-mobile': value,
+          },
+        });
+      });
+    });
   });
 });
 
@@ -267,6 +294,28 @@ describe('static properties only', () => {
           "background",
         }
       `);
+    });
+
+    describe('handles all scale keys', () => {
+      test.each([
+        ['$gray200', vars.color['gray200']],
+        ['$gray-500', vars.color['gray-500']],
+        ['$gray.500', vars.color['gray.500']],
+        ['$gray_500', vars.color['gray_500']],
+        ['$gray--500', vars.color['gray--500']],
+        ['$colors.gray-500', vars.color['colors.gray-500']],
+      ])(`%s`, (key, value) => {
+        expect(
+          rainbowSprinkles({
+            color: key as `$${keyof typeof vars['color']}`,
+          }),
+        ).toMatchObject({
+          className: 'color-mobile',
+          style: {
+            '--color-mobile': value,
+          },
+        });
+      });
     });
   });
 });

--- a/packages/rainbow-sprinkles/src/__tests__/createRainbowSprinkles.test.ts
+++ b/packages/rainbow-sprinkles/src/__tests__/createRainbowSprinkles.test.ts
@@ -298,22 +298,29 @@ describe('static properties only', () => {
 
     describe('parses scale values with hyphens, underscores, and periods', () => {
       test.each([
-        ['$gray200', vars.color['gray200']],
-        ['$gray-500', vars.color['gray-500']],
-        ['$gray.500', vars.color['gray.500']],
-        ['$gray_500', vars.color['gray_500']],
-        ['$gray--500', vars.color['gray--500']],
-        ['$colors.gray-500', vars.color['colors.gray-500']],
+        ['$gray200', 'gray200'],
+        ['$gray-500', 'gray-500'],
+        ['$gray.500', 'gray.500'],
+        ['$gray_500', 'gray_500'],
+        ['$gray--500', 'gray--500'],
+        ['$colors.gray-500', 'colors.gray-500'],
       ])(`%s`, (key, value) => {
+        expect(
+          rainbowSprinkles({
+            color: '$gray50',
+            padding: '$2x',
+            paddingRight: '-$3x',
+          }),
+        ).toMatchObject({
+          className:
+            'color-gray50-mobile padding-2x-mobile paddingRight--3x-mobile',
+        });
         expect(
           rainbowSprinkles({
             color: key as `$${keyof typeof vars['color']}`,
           }),
         ).toMatchObject({
-          className: 'color-mobile',
-          style: {
-            '--color-mobile': value,
-          },
+          className: `color-${value}-mobile`,
         });
       });
     });

--- a/packages/rainbow-sprinkles/src/__tests__/replaceVars.test.ts
+++ b/packages/rainbow-sprinkles/src/__tests__/replaceVars.test.ts
@@ -10,6 +10,8 @@ test('replaceVarsInValue', () => {
     '1x': '5px',
     '2x': '10px',
     '3x': '15px',
+    'gray-500': '#6b7280',
+    'gray.500': '#6b7280',
   };
 
   const run = (v: string) => replaceVarsInValue(v, scale);
@@ -22,6 +24,8 @@ test('replaceVarsInValue', () => {
   expect(run('-1x 2x')).toBe('-1x 2x');
   expect(run('calc(100% - $2x)')).toBe(`calc(100% - ${scale['2x']})`);
   expect(run('calc($3x - $2x)')).toBe(`calc(${scale['3x']} - ${scale['2x']})`);
+  expect(run('$gray-500')).toBe(scale['gray-500']);
+  expect(run('$gray.500')).toBe(scale['gray.500']);
 });
 
 test('getValueConfig', () => {
@@ -50,6 +54,20 @@ test('getValueConfig', () => {
         desktop: 'f',
       },
     },
+    'gray-500': {
+      default: 'light',
+      conditions: {
+        light: 'light',
+        dark: 'dark',
+      },
+    },
+    'gray.500': {
+      default: 'light',
+      conditions: {
+        light: 'light',
+        dark: 'dark',
+      },
+    },
   };
 
   const run = (v: string) => getValueConfig(v, scale);
@@ -61,4 +79,6 @@ test('getValueConfig', () => {
   expect(run('-1x')).toBe(null);
   expect(run('')).toBe(null);
   expect(run('$1x -$2x')).toBe(null);
+  expect(run('$gray-500')).toBe(scale['gray-500']);
+  expect(run('$gray.500')).toBe(scale['gray.500']);
 });

--- a/packages/rainbow-sprinkles/src/utils.ts
+++ b/packages/rainbow-sprinkles/src/utils.ts
@@ -8,7 +8,7 @@ import { CreateStylesOutput } from './types';
  * (\w+)  -> capture the "word" following the '$'
  * /g             -> capture all instances
  */
-export const VALUE_REGEX = /(-)?\B\$(\w+)/g;
+export const VALUE_REGEX = /(-)?\B\$([\w\-.]+)/g;
 
 export function mapValues<
   Value,

--- a/packages/rainbow-sprinkles/src/utils.ts
+++ b/packages/rainbow-sprinkles/src/utils.ts
@@ -5,7 +5,7 @@ import { CreateStylesOutput } from './types';
  *
  * (-)? -> optionally captures '-', names it "negated"
  * \B\$           -> capture '$' when preceded by a "non-word" (whitespace, punctuation)
- * (\w+)  -> capture the "word" following the '$'
+ * ([\w\-.]+)  -> capture the "word" following the '$', including hyphen and period characters
  * /g             -> capture all instances
  */
 export const VALUE_REGEX = /(-)?\B\$([\w\-.]+)/g;


### PR DESCRIPTION
## Description

This PR allows scale keys containing hyphens or periods to be used with rainbow-sprinkles.

This issue is documented here: https://github.com/wayfair/rainbow-sprinkles/discussions/102

But for further context, when defining properties, both sprinkles & rainbow sprinkles require scales to be flat (cannot have nested objects). As such, it's fairly common practice to flatten objects by concatenating the keys with a separator.

For example

```
const colors = {
  red: {
    500: "#ef4444"
    // ... etc
  }
}
```

Might become
```
defineProperties({
  colors: {
    'red-500': '#ef4444'
    // or 'red.500'
  }
})
```

Unfortunately, when scale keys like this are used, rainbow sprinkles fails to pick them up.

The fault is in the `VALUE_REGEX`, which assumes all values will match the `\w` (word character) matcher.

I have taken the simplest approach to fixing this, by just adding the hyphen (-) and period (.) characters to the capturing group, however there are definitely other solutions.

**Note** I haven't added any such keys to the test cases, as I wanted to keep the blast-radius small. However I am more than happy to add that if the maintainer/s desire 🙏 

Finally, I absolutely love this fantastic library, than you for the hard work ❤️ 

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair/rainbow-sprinkles/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
