### PR TITLE
Fix formatting in README.md

### DIFF
--- a/packages/rainbow-sprinkles/README.md
+++ b/packages/rainbow-sprinkles/README.md
@@ -115,7 +115,7 @@ const responsiveProperties = defineProperties({
   },
 });
 
-export const rainbowSprinkles(responsiveProperties)
+export const rainbowSprinkles = createRainbowSprinkles(responsiveProperties);
 
 export type Sprinkles = Parameters<typeof rainbowSprinkles>[0];
 ```
@@ -175,6 +175,7 @@ const properties = defineProperties({
   '@layer': sprinklesLayer
   // etc.
 });
+```
 
 ### `dynamicProperties` vs `staticProperties`
 


### PR DESCRIPTION
Thanks for this library!

## Description

* Updated the `rainbowSprinkles` export line to reflect the name of the create function.
* Added missing backticks to close a code example.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/wayfair/rainbow-sprinkles/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
