### PR TITLE
fix rainbow sprinkles setup example code

### DIFF
--- a/packages/rainbow-sprinkles/README.md
+++ b/packages/rainbow-sprinkles/README.md
@@ -57,7 +57,7 @@ import { defineProperties, createRainbowSprinkles } from 'rainbow-sprinkles';
 // or import a theme (e.g. `createTheme`, `createThemeContract`)
 const vars = {
   space: {
-    none: 0,
+    none: '0',
     small: '4px',
     medium: '8px',
     large: '16px',


### PR DESCRIPTION
## Description

In the example code, a type error occurred when the value of the object element of space was a number rather than a string, so this was corrected.


## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair/rainbow-sprinkles/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
